### PR TITLE
pass through Zip and Io errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip-extensions"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Matthias Friedrich <rushiblegit@gmail.com>"]
 edition = "2018"
 description = "An extension create for zip."
@@ -15,4 +15,4 @@ exclude = [
 ]
 
 [dependencies]
-zip = "0.5.5"
+zip = "0.5.8"

--- a/src/write.rs
+++ b/src/write.rs
@@ -15,7 +15,7 @@ pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) ->
 
 /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
 pub fn zip_create_from_directory_with_options(archive_file: &PathBuf, directory: &PathBuf, options: FileOptions) -> ZipResult<()> {
-    let file = File::create(archive_file).unwrap();
+    let file = File::create(archive_file)?;
     let mut zip_writer = zip::ZipWriter::new(file);
     zip_writer.create_from_directory_with_options(directory, options)
 }
@@ -40,29 +40,28 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
 
         let mut buffer = Vec::new();
 
-        while paths_queue.len() > 0 {
-            let next = paths_queue.pop().unwrap();
-            let directory_entry_iterator = std::fs::read_dir(next).unwrap();
+        while let Some(next) = paths_queue.pop() {
+            let directory_entry_iterator = std::fs::read_dir(next)?;
 
             for entry in directory_entry_iterator {
-                let entry_path = entry.unwrap().path();
-                let entry_metadata = std::fs::metadata(entry_path.clone()).unwrap();
+                let entry_path = entry?.path();
+                let entry_metadata = std::fs::metadata(entry_path.clone())?;
                 if entry_metadata.is_file() {
-                    let mut f = File::open(&entry_path).unwrap();
-                    f.read_to_end(&mut buffer).unwrap();
+                    let mut f = File::open(&entry_path)?;
+                    f.read_to_end(&mut buffer)?;
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.start_file_from_path(&relative_path, options).unwrap();
-                    self.write_all(buffer.as_ref()).unwrap();
+                    self.start_file_from_path(&relative_path, options)?;
+                    self.write_all(buffer.as_ref())?;
                     buffer.clear();
                 } else if entry_metadata.is_dir() {
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.add_directory_from_path(&relative_path, options).unwrap();
+                    self.add_directory_from_path(&relative_path, options)?;
                     paths_queue.push(entry_path.clone());
                 }
             }
         }
 
-        self.finish().unwrap();
+        self.finish()?;
         Ok(())
     }
 }


### PR DESCRIPTION
replaces all instances of unwrap() so the library no longer panics

Most methods were returning ZipResult already which can transparently pass through IO errors, but one had to be changed to eliminate all panics.  I'm not using this one personally (just the writer extensions) so I can change it back if it's a problem but I wanted to send a patch fixing everything and not just the one part I used.  :-)

I also pushed a commit bumping semver since the signature of a method changed.