### PR TITLE
Fix formatting and lints

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -5,7 +5,7 @@ use std::path::{Component, PathBuf};
 
 /// Writes all bytes to a file.
 pub fn file_write_all_bytes(path: PathBuf, bytes: &[u8], overwrite: bool) -> io::Result<usize> {
-    if path.exists() && overwrite == false {
+    if path.exists() && !overwrite {
         return Err(Error::new(
             ErrorKind::AlreadyExists,
             "The specified file already exists.",
@@ -25,7 +25,7 @@ pub(crate) fn make_relative_path(root: &PathBuf, current: &PathBuf) -> PathBuf {
         let current_path_component: Component = current_components[i];
         if i < root_components.len() {
             let other: Component = root_components[i];
-            if other.eq(&current_path_component) == false {
+            if other != current_path_component {
                 break;
             }
         } else {

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -1,12 +1,15 @@
-use std::path::{PathBuf, Component};
 use std::fs::File;
-use std::io::{Write, Error, ErrorKind};
 use std::io;
+use std::io::{Error, ErrorKind, Write};
+use std::path::{Component, PathBuf};
 
 /// Writes all bytes to a file.
 pub fn file_write_all_bytes(path: PathBuf, bytes: &[u8], overwrite: bool) -> io::Result<usize> {
     if path.exists() && overwrite == false {
-        return Err(Error::new(ErrorKind::AlreadyExists, "The specified file already exists."));
+        return Err(Error::new(
+            ErrorKind::AlreadyExists,
+            "The specified file already exists.",
+        ));
     }
     let mut file = File::create(path)?;
     file.set_len(0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod write;
 
 #[cfg(test)]
 mod tests {
-    use crate::{is_zip, zip_create_from_directory};
-    use std::fs::File;
+    use crate::is_zip;
+    use std::fs::{self, File};
     use std::path::PathBuf;
     use std::str::FromStr;
 
@@ -29,7 +29,7 @@ mod tests {
         zip_writer.set_comment("This is an empty ZIP file.");
         zip_writer.finish().unwrap();
         let actual = is_zip(&archive_file);
-        std::fs::remove_file(&archive_file.as_path());
+        fs::remove_file(&archive_file.as_path()).unwrap();
         assert_eq!(actual, true)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ pub mod write;
 #[cfg(test)]
 mod tests {
     use crate::{is_zip, zip_create_from_directory};
+    use std::fs::File;
     use std::path::PathBuf;
     use std::str::FromStr;
-    use std::fs::File;
 
     #[test]
     fn is_zip_returns_false_if_file_does_not_exists() {

--- a/src/read.rs
+++ b/src/read.rs
@@ -43,7 +43,7 @@ pub fn zip_extract_file_to_memory(
         Some(index) => index,
         None => return Err(ZipError::FileNotFound),
     };
-    return archive.extract_file_to_memory(file_number, buffer);
+    archive.extract_file_to_memory(file_number, buffer)
 }
 
 /// Determines whether the specified file is a ZIP file, or not.
@@ -71,10 +71,7 @@ pub fn try_is_zip(file: &PathBuf) -> ZipResult<bool> {
 
 /// Determines whether the specified file is a ZIP file, or not.
 pub fn is_zip(file: &PathBuf) -> bool {
-    match try_is_zip(file) {
-        Ok(r) => r,
-        Err(_) => false,
-    }
+    try_is_zip(file).unwrap_or_default()
 }
 
 pub trait ZipArchiveExtensions {
@@ -102,7 +99,7 @@ pub trait ZipArchiveExtensions {
 
 impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
     fn extract(&mut self, target_directory: &PathBuf) -> ZipResult<()> {
-        if target_directory.is_dir() == false {
+        if !target_directory.is_dir() {
             return Err(ZipError::Io(Error::new(
                 ErrorKind::InvalidInput,
                 "The specified path does not indicate a valid directory path.",
@@ -139,7 +136,7 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
             buffer.as_ref(),
             overwrite,
         )?;
-        return Ok(());
+        Ok(())
     }
 
     fn extract_file_to_memory(
@@ -152,15 +149,15 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
             let _bytes_read = next.read_to_end(buffer)?;
             return Ok(());
         }
-        return Err(ZipError::Io(Error::new(
+        Err(ZipError::Io(Error::new(
             ErrorKind::InvalidInput,
             "The specified index does not indicate a file entry.",
-        )));
+        )))
     }
 
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf> {
         let next: ZipFile = self.by_index(file_number)?;
-        return Ok(next.sanitized_name());
+        Ok(next.sanitized_name())
     }
 
     fn file_number(&mut self, entry_path: &PathBuf) -> Option<usize> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,11 +1,11 @@
-use std::io::{Read, Error, ErrorKind};
-use std::io;
-use zip::ZipArchive;
-use std::path::PathBuf;
-use zip::read::ZipFile;
-use zip::result::{ZipResult, ZipError};
 use crate::file_utils::file_write_all_bytes;
 use std::fs::File;
+use std::io;
+use std::io::{Error, ErrorKind, Read};
+use std::path::PathBuf;
+use zip::read::ZipFile;
+use zip::result::{ZipError, ZipResult};
+use zip::ZipArchive;
 
 /// Extracts a ZIP file to the given directory.
 pub fn zip_extract(archive_file: &PathBuf, target_dir: &PathBuf) -> ZipResult<()> {
@@ -15,24 +15,33 @@ pub fn zip_extract(archive_file: &PathBuf, target_dir: &PathBuf) -> ZipResult<()
 }
 
 /// Extracts and entry in the ZIP archive to the given directory.
-pub fn zip_extract_file(archive_file: &PathBuf, entry_path: &PathBuf, target_dir: &PathBuf, overwrite: bool) -> ZipResult<()> {
+pub fn zip_extract_file(
+    archive_file: &PathBuf,
+    entry_path: &PathBuf,
+    target_dir: &PathBuf,
+    overwrite: bool,
+) -> ZipResult<()> {
     let file = File::open(archive_file)?;
     let mut archive = zip::ZipArchive::new(file)?;
     let file_number: usize = match archive.file_number(entry_path) {
         Some(index) => index,
-        None => return Err(ZipError::FileNotFound)
+        None => return Err(ZipError::FileNotFound),
     };
     let destination_file_path = target_dir.join(entry_path);
     archive.extract_file(file_number, &destination_file_path, overwrite)
 }
 
 /// Extracts an entry in the ZIP archive to the given memory buffer.
-pub fn zip_extract_file_to_memory(archive_file: &PathBuf, entry_path: &PathBuf, buffer: &mut Vec<u8>) -> ZipResult<()> {
+pub fn zip_extract_file_to_memory(
+    archive_file: &PathBuf,
+    entry_path: &PathBuf,
+    buffer: &mut Vec<u8>,
+) -> ZipResult<()> {
     let file = File::open(archive_file)?;
     let mut archive = zip::ZipArchive::new(file)?;
     let file_number: usize = match archive.file_number(entry_path) {
         Some(index) => index,
-        None => return Err(ZipError::FileNotFound)
+        None => return Err(ZipError::FileNotFound),
     };
     return archive.extract_file_to_memory(file_number, buffer);
 }
@@ -73,10 +82,16 @@ pub trait ZipArchiveExtensions {
     fn extract(&mut self, path: &PathBuf) -> ZipResult<()>;
 
     /// Extracts an entry in the zip archive to a file.
-    fn extract_file(&mut self, file_number: usize, destination_file_path: &PathBuf, overwrite: bool) -> ZipResult<()>;
+    fn extract_file(
+        &mut self,
+        file_number: usize,
+        destination_file_path: &PathBuf,
+        overwrite: bool,
+    ) -> ZipResult<()>;
 
     /// Extracts an entry in the ZIP archive to the given memory buffer.
-    fn extract_file_to_memory(&mut self, file_number: usize, buffer: &mut Vec<u8>) -> ZipResult<()>;
+    fn extract_file_to_memory(&mut self, file_number: usize, buffer: &mut Vec<u8>)
+        -> ZipResult<()>;
 
     /// Gets an entry´s path.
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf>;
@@ -88,7 +103,10 @@ pub trait ZipArchiveExtensions {
 impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
     fn extract(&mut self, target_directory: &PathBuf) -> ZipResult<()> {
         if target_directory.is_dir() == false {
-            return Err(ZipError::Io(Error::new(ErrorKind::InvalidInput, "The specified path does not indicate a valid directory path.")));
+            return Err(ZipError::Io(Error::new(
+                ErrorKind::InvalidInput,
+                "The specified path does not indicate a valid directory path.",
+            )));
         }
 
         for file_number in 0..self.len() {
@@ -108,20 +126,36 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
         Ok(())
     }
 
-    fn extract_file(&mut self, file_number: usize, destination_file_path: &PathBuf, overwrite: bool) -> ZipResult<()> {
+    fn extract_file(
+        &mut self,
+        file_number: usize,
+        destination_file_path: &PathBuf,
+        overwrite: bool,
+    ) -> ZipResult<()> {
         let mut buffer: Vec<u8> = Vec::new();
         self.extract_file_to_memory(file_number, &mut buffer)?;
-        file_write_all_bytes(destination_file_path.to_path_buf(), buffer.as_ref(), overwrite)?;
+        file_write_all_bytes(
+            destination_file_path.to_path_buf(),
+            buffer.as_ref(),
+            overwrite,
+        )?;
         return Ok(());
     }
 
-    fn extract_file_to_memory(&mut self, file_number: usize, buffer: &mut Vec<u8>) -> ZipResult<()> {
+    fn extract_file_to_memory(
+        &mut self,
+        file_number: usize,
+        buffer: &mut Vec<u8>,
+    ) -> ZipResult<()> {
         let mut next: ZipFile = self.by_index(file_number)?;
         if next.is_file() {
             let _bytes_read = next.read_to_end(buffer)?;
             return Ok(());
         }
-        return Err(ZipError::Io(Error::new(ErrorKind::InvalidInput, "The specified index does not indicate a file entry.")));
+        return Err(ZipError::Io(Error::new(
+            ErrorKind::InvalidInput,
+            "The specified index does not indicate a file entry.",
+        )));
     }
 
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,11 +1,11 @@
+use crate::file_utils::make_relative_path;
 use std::fs::File;
-use std::io::{Write, Read};
 use std::io;
+use std::io::{Read, Write};
 use std::path::PathBuf;
-use zip::{ZipWriter, write, CompressionMethod};
 use zip::result::ZipResult;
 use zip::write::FileOptions;
-use crate::file_utils::make_relative_path;
+use zip::{write, CompressionMethod, ZipWriter};
 
 /// Creates a zip archive that contains the files and directories from the specified directory.
 pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) -> ZipResult<()> {
@@ -14,7 +14,11 @@ pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) ->
 }
 
 /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-pub fn zip_create_from_directory_with_options(archive_file: &PathBuf, directory: &PathBuf, options: FileOptions) -> ZipResult<()> {
+pub fn zip_create_from_directory_with_options(
+    archive_file: &PathBuf,
+    directory: &PathBuf,
+    options: FileOptions,
+) -> ZipResult<()> {
     let file = File::create(archive_file)?;
     let mut zip_writer = zip::ZipWriter::new(file);
     zip_writer.create_from_directory_with_options(directory, options)
@@ -25,7 +29,11 @@ pub trait ZipWriterExtensions {
     fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()>;
 
     /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-    fn create_from_directory_with_options(&mut self, directory: &PathBuf, options: FileOptions) -> ZipResult<()>;
+    fn create_from_directory_with_options(
+        &mut self,
+        directory: &PathBuf,
+        options: FileOptions,
+    ) -> ZipResult<()>;
 }
 
 impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
@@ -34,7 +42,11 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
         self.create_from_directory_with_options(directory, options)
     }
 
-    fn create_from_directory_with_options(&mut self, directory: &PathBuf, options: FileOptions) -> ZipResult<()> {
+    fn create_from_directory_with_options(
+        &mut self,
+        directory: &PathBuf,
+        options: FileOptions,
+    ) -> ZipResult<()> {
         let mut paths_queue: Vec<PathBuf> = vec![];
         paths_queue.push(directory.clone());
 


### PR DESCRIPTION
Hello, thanks for the crate! It made it really easy to setup zipping entire directories in my unit testing.

I'm planning on submitting a couple more PRs, but I wanted to get formatting and `clippy` lints / compiler warnings out of the way first. There are still some deprecation warnings from `zip` left to get through, but I was planning on setting up a different issue/PR to deal with that since it involves changing some of the behavior in this crate.

The formatting vs lints and warnings is broken out into two separate commits if you want to see the changes from each one just as a heads up.