### PR TITLE
Release 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zip-extensions"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Matthias Friedrich <rushiblegit@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "An extension crate for zip."
 readme = "README.md"
 repository = "https://github.com/matzefriedrich/zip-extensions-rs"
@@ -15,4 +15,4 @@ exclude = [
 ]
 
 [dependencies]
-zip = "0.5"
+zip = "0.6.2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 - 2021 Matthias Friedrich
+Copyright (c) 2020 - 2023 Matthias Friedrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following dependencies to the `Cargo.toml` file.
 
 ````toml
 [dependencies]
-zip = "0.5"
+zip = "0.6"
 zip-extensions = "0.6"
 ````
 

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -34,3 +34,17 @@ pub(crate) fn make_relative_path(root: &PathBuf, current: &PathBuf) -> PathBuf {
     }
     result
 }
+
+// Returns a String representing the given Path.
+pub(crate) fn path_as_string(path: &std::path::Path) -> String {
+    let mut path_str = String::new();
+    for component in path.components() {
+        if let std::path::Component::Normal(os_str) = component {
+            if !path_str.is_empty() {
+                path_str.push('/');
+            }
+            path_str.push_str(&*os_str.to_string_lossy());
+        }
+    }
+    path_str
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -108,7 +108,7 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
 
         for file_number in 0..self.len() {
             let mut next: ZipFile = self.by_index(file_number)?;
-            let sanitized_name = next.sanitized_name();
+            let sanitized_name = next.mangled_name();
             if next.is_dir() {
                 let extracted_folder_path = target_directory.join(sanitized_name);
                 std::fs::create_dir_all(extracted_folder_path)?;
@@ -157,13 +157,13 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
 
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf> {
         let next: ZipFile = self.by_index(file_number)?;
-        Ok(next.sanitized_name())
+        Ok(next.mangled_name())
     }
 
     fn file_number(&mut self, entry_path: &PathBuf) -> Option<usize> {
         for file_number in 0..self.len() {
             if let Ok(next) = self.by_index(file_number) {
-                let sanitized_name = next.sanitized_name();
+                let sanitized_name = next.mangled_name();
                 if sanitized_name == *entry_path {
                     return Some(file_number);
                 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,4 +1,4 @@
-use crate::file_utils::make_relative_path;
+use crate::file_utils::{make_relative_path, path_as_string};
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
@@ -62,12 +62,12 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
                     let mut f = File::open(&entry_path)?;
                     f.read_to_end(&mut buffer)?;
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.start_file_from_path(&relative_path, options)?;
+                    self.start_file(path_as_string(&relative_path), options)?;
                     self.write_all(buffer.as_ref())?;
                     buffer.clear();
                 } else if entry_metadata.is_dir() {
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.add_directory_from_path(&relative_path, options)?;
+                    self.add_directory(path_as_string(&relative_path), options)?;
                     paths_queue.push(entry_path.clone());
                 }
             }


### PR DESCRIPTION
* Upgrades the zip dependency to version 0.6.2
* Changes all usages of sanitized_name() to mangled_name()
* Fixes warnings regarding the usage of deprecated methods in create_from_directory_with_options

* Updates the copyright notice in the license file
* Updates the README.md file