### PR TITLE
Add support for setting per-item `FileOptions` (mapping)

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -10,18 +10,21 @@ use zip::{write, CompressionMethod, ZipWriter};
 /// Creates a zip archive that contains the files and directories from the specified directory.
 pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) -> ZipResult<()> {
     let options = write::FileOptions::default().compression_method(CompressionMethod::Stored);
-    zip_create_from_directory_with_options(archive_file, directory, options)
+    zip_create_from_directory_with_options(archive_file, directory, |_| options)
 }
 
 /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-pub fn zip_create_from_directory_with_options(
+pub fn zip_create_from_directory_with_options<F>(
     archive_file: &PathBuf,
     directory: &PathBuf,
-    options: FileOptions,
-) -> ZipResult<()> {
+    options_map: F,
+) -> ZipResult<()>
+where
+    F: Fn(&PathBuf) -> FileOptions,
+{
     let file = File::create(archive_file)?;
     let mut zip_writer = zip::ZipWriter::new(file);
-    zip_writer.create_from_directory_with_options(directory, options)
+    zip_writer.create_from_directory_with_options(directory, options_map)
 }
 
 pub trait ZipWriterExtensions {
@@ -29,24 +32,29 @@ pub trait ZipWriterExtensions {
     fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()>;
 
     /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-    fn create_from_directory_with_options(
+    fn create_from_directory_with_options<F>(
         &mut self,
         directory: &PathBuf,
-        options: FileOptions,
-    ) -> ZipResult<()>;
+        options_map: F,
+    ) -> ZipResult<()>
+    where
+        F: Fn(&PathBuf) -> FileOptions;
 }
 
 impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
     fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()> {
         let options = write::FileOptions::default().compression_method(CompressionMethod::Stored);
-        self.create_from_directory_with_options(directory, options)
+        self.create_from_directory_with_options(directory, |_| options)
     }
 
-    fn create_from_directory_with_options(
+    fn create_from_directory_with_options<F>(
         &mut self,
         directory: &PathBuf,
-        options: FileOptions,
-    ) -> ZipResult<()> {
+        options_map: F,
+    ) -> ZipResult<()>
+    where
+        F: Fn(&PathBuf) -> FileOptions,
+    {
         let mut paths_queue: Vec<PathBuf> = vec![];
         paths_queue.push(directory.clone());
 
@@ -57,17 +65,18 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
 
             for entry in directory_entry_iterator {
                 let entry_path = entry?.path();
+                let file_options = options_map(&entry_path);
                 let entry_metadata = std::fs::metadata(entry_path.clone())?;
                 if entry_metadata.is_file() {
                     let mut f = File::open(&entry_path)?;
                     f.read_to_end(&mut buffer)?;
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.start_file(path_as_string(&relative_path), options)?;
+                    self.start_file(path_as_string(&relative_path), file_options)?;
                     self.write_all(buffer.as_ref())?;
                     buffer.clear();
                 } else if entry_metadata.is_dir() {
                     let relative_path = make_relative_path(&directory, &entry_path);
-                    self.add_directory(path_as_string(&relative_path), options)?;
+                    self.add_directory(path_as_string(&relative_path), file_options)?;
                     paths_queue.push(entry_path.clone());
                 }
             }


### PR DESCRIPTION
This PR implements the feature discussed in #12, allowing an instance of `FileOptions` to be set for each file or directory processed by `create_from_directory_with_options()`. As mentioned there, this API refactor would be a breaking change.

**Current usage of the API:**

```rust
let mut zip = ZipWriter::new(file);

// This has the limitation of only allowing one configuration for all the files and directories.
zip.create_from_directory_with_options(
    &PathBuf::from(&source_dir),
    FileOptions::default(),
);
```

**API usage with this PR:**

```rust
let mut zip = ZipWriter::new(file);

zip.create_from_directory_with_options(&PathBuf::from(&source_dir), |file: &PathBuf| {
    if file.eq(&PathBuf::from("dir/my_executable")) {
        FileOptions::default().unix_permissions(0o775)
    } else {
        FileOptions::default()
    }
});
```