### PR TITLE
Feature/upgrade zip2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,19 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: 
+      - master
+      - feature/*
+      - fix/*
+
   pull_request:
-    branches: [ master ]
+    branches: 
+      - master
+      - feature/*
+      - fix/*
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:
@@ -13,7 +23,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2024-06-02
+
+The project is going to follow the active development of the `zip` crate and thus has been updated to work witj **zip2**; so this release comes with a bunch of breaking changes.
+
+### Changed
+
+- Upgrades the `zip` package reference; uses the new **zip2** version
+- Adds `FileOptionExtension` type argument to the `zip_create_from_directory_with_options` trait and implementation to address zip2 build errors
+- Removes `mut` modifier from extensions for `ZipWriter<W>` because it no longer implements the `Copy` trait
+
+
 ## [0.7.0] - 2024-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.7.0] - 2024-06-02
+## [0.8.0] - 2024-06-02
 
-The project is going to follow the active development of the `zip` crate and thus has been updated to work witj **zip2**; so this release comes with a bunch of breaking changes.
+The project follows the active development of the `zip` crate and has thus been updated to work with **zip2**; this release comes with several breaking changes in the `write` module.
 
 ### Changed
 
 - Upgrades the `zip` package reference; uses the new **zip2** version
-- Adds `FileOptionExtension` type argument to the `zip_create_from_directory_with_options` trait and implementation to address zip2 build errors
-- Removes `mut` modifier from extensions for `ZipWriter<W>` because it no longer implements the `Copy` trait
+- Adds `FileOptionExtension` type argument to the `zip_create_from_directory_with_options` trait and implementation to address zip2 build issues
+- Removes the `mut` modifier from the `ZipWriterExtensions` to fix issues
 
 
 ## [0.7.0] - 2024-06-01

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip-extensions"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Matthias Friedrich <rushiblegit@gmail.com>"]
 edition = "2021"
 description = "An extension crate for zip."
@@ -15,4 +15,4 @@ exclude = [
 ]
 
 [dependencies]
-zip = "0.6.6"
+zip = "2.1.1"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Crates.io](https://img.shields.io/crates/v/zip-extensions)
 
 
-An extension crate for https://github.com/mvdnes/zip-rs that provides high-level functions for common ZIP tasks, such as extracting archives to a directory.
+An extension crate for https://github.com/zip-rs/zip2 that provides high-level functions for common ZIP tasks, such as extracting archives to a directory.
 
 ## Usage examples
 
@@ -15,11 +15,11 @@ Add the following dependencies to the `Cargo.toml` file.
 
 ````toml
 [dependencies]
-zip = "0.6"
-zip-extensions = "0.6"
+zip = "2.1.1"
+zip-extensions = "2.7.0"
 ````
 
-See https://github.com/mvdnes/zip-rs fur further information about `zip` dependencies.
+See https://github.com/zip-rs/zip2 fur further information about `zip` dependencies.
 
 ### Extracting an archive to a directory
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # zip-extensions-rs
 
 ![Rust](https://github.com/matzefriedrich/zip-extensions-rs/workflows/Rust/badge.svg)
-[![Build status](https://ci.appveyor.com/api/projects/status/41lavncr30iyv5rk/branch/master?svg=true)](https://ci.appveyor.com/project/matzefriedrich/zip-extensions-rs/branch/master)
 ![Crates.io](https://img.shields.io/crates/v/zip-extensions)
 
 
@@ -16,7 +15,7 @@ Add the following dependencies to the `Cargo.toml` file.
 ````toml
 [dependencies]
 zip = "2.1.1"
-zip-extensions = "2.7.0"
+zip-extensions = "0.8.0"
 ````
 
 See https://github.com/zip-rs/zip2 fur further information about `zip` dependencies.
@@ -72,7 +71,7 @@ use zip_extensions::write::ZipWriterExtensions;
 ...
 
 let file = File::create(archive_file)?;
-let mut zip = ZipWriter::new(file);
+let zip = ZipWriter::new(file);
 zip.create_from_directory(&source_path)?;
 ````
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,0 @@
-image: Ubuntu
-install:
-    - sh: |
-        sudo apt-get -y update && sudo apt-get -y upgrade && sudo apt-get -y install curl mingw-w64
-        sudo curl https://sh.rustup.rs -sSf | sh -s -- -y
-        export PATH="$HOME/.cargo/bin:$PATH"
-build_script:
-    - sh: cargo build

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,57 +5,60 @@ use std::path::PathBuf;
 
 use zip::{CompressionMethod, ZipWriter};
 use zip::result::ZipResult;
-use zip::write::FileOptions;
+use zip::write::{FileOptionExtension, FileOptions, SimpleFileOptions};
 
 use crate::file_utils::{make_relative_path, path_as_string};
 
 /// Creates a zip archive that contains the files and directories from the specified directory.
 pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) -> ZipResult<()> {
-    let options = FileOptions::default().compression_method(CompressionMethod::Stored);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
     zip_create_from_directory_with_options(archive_file, directory, |_| options)
 }
 
 /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-pub fn zip_create_from_directory_with_options<F>(
+pub fn zip_create_from_directory_with_options<F, T>(
     archive_file: &PathBuf,
     directory: &PathBuf,
-    options_map: F,
+    cb_file_options: F,
 ) -> ZipResult<()>
 where
-    F: Fn(&PathBuf) -> FileOptions,
+    T: FileOptionExtension,
+    F: Fn(&PathBuf) -> FileOptions<T>,
 {
     let file = File::create(archive_file)?;
-    let mut zip_writer = ZipWriter::new(file);
-    zip_writer.create_from_directory_with_options(directory, options_map)
+    let zip_writer = ZipWriter::new(file);
+    zip_writer.create_from_directory_with_options(directory, cb_file_options)
 }
 
 pub trait ZipWriterExtensions {
     /// Creates a zip archive that contains the files and directories from the specified directory.
-    fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()>;
+    fn create_from_directory(self, directory: &PathBuf) -> ZipResult<()>;
 
     /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
-    fn create_from_directory_with_options<F>(
-        &mut self,
+    fn create_from_directory_with_options<F, T>(
+        self,
         directory: &PathBuf,
-        options_map: F,
+        cb_file_options: F,
     ) -> ZipResult<()>
     where
-        F: Fn(&PathBuf) -> FileOptions;
+        T: FileOptionExtension,
+        F: Fn(&PathBuf) -> FileOptions<T>;
 }
 
 impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
-    fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()> {
-        let options = FileOptions::default().compression_method(CompressionMethod::Stored);
+    fn create_from_directory(self, directory: &PathBuf) -> ZipResult<()> {
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
         self.create_from_directory_with_options(directory, |_| options)
     }
 
-    fn create_from_directory_with_options<F>(
-        &mut self,
+    fn create_from_directory_with_options<F, T>(
+        mut self,
         directory: &PathBuf,
-        options_map: F,
+        cb_file_options: F,
     ) -> ZipResult<()>
     where
-        F: Fn(&PathBuf) -> FileOptions,
+        T: FileOptionExtension,
+        F: Fn(&PathBuf) -> FileOptions<T>,
     {
         let mut paths_queue: Vec<PathBuf> = vec![];
         paths_queue.push(directory.clone());
@@ -67,7 +70,7 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
 
             for entry in directory_entry_iterator {
                 let entry_path = entry?.path();
-                let file_options = options_map(&entry_path);
+                let file_options = cb_file_options(&entry_path);
                 let entry_metadata = std::fs::metadata(entry_path.clone())?;
                 if entry_metadata.is_file() {
                     let mut f = File::open(&entry_path)?;


### PR DESCRIPTION
- Upgrades the `zip` package reference; uses the new **zip2** version
- Adds `FileOptionExtension` type argument to the `zip_create_from_directory_with_options` trait and implementation to address zip2 build issues
- Removes the `mut` modifier from the `ZipWriterExtensions` to fix issues