### PR TITLE
Bump zip from 2.1 to 2.6, and fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2025-04-22
+
+### Changed
+
+- [PR #20] Updated zip crate dependency from version 2.1 to 2.6 and removed the no longer supported `rand` feature.
+- [PR #20] Replaced `ZipFile` with `ZipFile<R>` to fix missing generics.
+
+
 ## [0.8.1] - 2024-07-26
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip-extensions"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Matthias Friedrich <rushiblegit@gmail.com>"]
 edition = "2021"
 description = "An extension crate for zip."
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [dependencies]
-zip = { version = "2.1", default-features = false }
+zip = { version = "2.6", default-features = false }
 
 [features]
 aes-crypto = ["zip/aes-crypto" ]
@@ -38,7 +38,6 @@ constant_time_eq = ["zip/constant_time_eq"]
 hmac = ["zip/hmac"]
 pbkdf2 = ["zip/pbkdf2"]
 sha1 = ["zip/sha1"]
-rand = ["zip/rand"]
 zeroize = ["zip/zeroize"]
 zopfli = ["zip/zopfli"]
 flate2 = ["zip/flate2"]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Add the following dependencies to the `Cargo.toml` file.
 
 ````toml
 [dependencies]
-zip = "2.1.1"
-zip-extensions = "0.8.1"
+zip = "2.6"
+zip-extensions = "0.8.2"
 ````
 
 See https://github.com/zip-rs/zip2 fur further information about `zip` dependencies.

--- a/src/read.rs
+++ b/src/read.rs
@@ -107,7 +107,7 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
         }
 
         for file_number in 0..self.len() {
-            let mut next: ZipFile = self.by_index(file_number)?;
+            let mut next: ZipFile<R> = self.by_index(file_number)?;
             let sanitized_name = next.mangled_name();
             if next.is_dir() {
                 let extracted_folder_path = target_directory.join(sanitized_name);
@@ -144,7 +144,7 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
         file_number: usize,
         buffer: &mut Vec<u8>,
     ) -> ZipResult<()> {
-        let mut next: ZipFile = self.by_index(file_number)?;
+        let mut next: ZipFile<R> = self.by_index(file_number)?;
         if next.is_file() {
             let _bytes_read = next.read_to_end(buffer)?;
             return Ok(());
@@ -156,7 +156,7 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
     }
 
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf> {
-        let next: ZipFile = self.by_index(file_number)?;
+        let next: ZipFile<R> = self.by_index(file_number)?;
         Ok(next.mangled_name())
     }
 


### PR DESCRIPTION
### Changes

- Updated zip crate dependency from version 2.1 to 2.6 and removed the no longer supported `rand` feature.
- Replaced `ZipFile` with `ZipFile<R>` to fix missing generics.