### PR TITLE
Bump zip from 2.6 to 3.0, and fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2025-05-16
+
+Upgraded the `zip` crate from version `2.6` to `3.0` and updated related feature flags.
+
+### Changed
+
+- [PR #21] Removed obsolete features and added new ones such as `nt-time` and `jiff-02`. Adjusted the default features list accordingly. 
+
+
 ## [0.8.2] - 2025-04-22
 
 ### Changed
 
-- [PR #20] Updated zip crate dependency from version 2.1 to 2.6 and removed the no longer supported `rand` feature.
+- [PR #20] Updated zip crate dependency from version `2.1` to `2.6` and removed the no longer supported `rand` feature.
 - [PR #20] Replaced `ZipFile` with `ZipFile<R>` to fix missing generics.
 
 
@@ -36,14 +45,14 @@ The project follows the active development of the `zip` crate and has thus been 
 ### Changed
 
 - [PR #13] Adds support for per-item file options by the `create_from_directory_with_options` method. This introduces a breaking change; instead of passing a `FileOptions` directly an `Fn` must be specified that is called for each file, and must return a `FileOptions` value.
-- Upgraded the zip dependency to version 0.6.6.
+- Upgraded the zip dependency to version `0.6.6`.
 
 
 ## [0.6.2] - 2023-09-03
 
 ### Changed
 
-- [PR #10] Upgraded the zip dependency to version 0.6.2
+- [PR #10] Upgraded the zip dependency to version `0.6.2`
 
 
 ## [0.6.1] - 2021-07-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zip-extensions"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Matthias Friedrich <rushiblegit@gmail.com>"]
 edition = "2021"
 description = "An extension crate for zip."
@@ -15,40 +15,23 @@ exclude = [
 ]
 
 [dependencies]
-zip = { version = "2.6", default-features = false }
+zip = { version = "3.0", default-features = false }
 
 [features]
 aes-crypto = ["zip/aes-crypto" ]
 chrono = ["zip/chrono"]
 deflate = ["zip/deflate"]
 deflate-flate2 = ["zip/deflate-flate2"]
-deflate-miniz = ["zip/deflate-miniz"]
-deflate-zlib = ["zip/deflate-zlib"]
-deflate-zlib-ng = ["zip/deflate-zlib-ng"]
+deflate-flate2-zlib = ["zip/deflate-flate2-zlib"]
+deflate-flate2-zlib-rs = ["zip/deflate-flate2-zlib-rs"]
 deflate-zopfli = ["zip/deflate-zopfli"]
+jiff-02 = ["zip/jiff-02"]
 lzma = ["zip/lzma"]
-unreserved = ["zip/unreserved"]
+nt-time = ["zip/nt-time"]
 xz = ["zip/xz"]
-bzip2 = ["zip/bzip2"]
-deflate64 = ["zip/deflate64"]
-time = ["zip/time"]
-zstd = ["zip/zstd"]
-aes = ["zip/aes"]
-constant_time_eq = ["zip/constant_time_eq"]
-hmac = ["zip/hmac"]
-pbkdf2 = ["zip/pbkdf2"]
-sha1 = ["zip/sha1"]
-zeroize = ["zip/zeroize"]
-zopfli = ["zip/zopfli"]
-flate2 = ["zip/flate2"]
-lzma-rs = ["zip/lzma-rs"]
 default = [
     "aes-crypto",
-    "bzip2",
-    "deflate64",
     "deflate",
     "lzma",
-    "time",
-    "zstd",
     "xz",
 ]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Add the following dependencies to the `Cargo.toml` file.
 
 ````toml
 [dependencies]
-zip = "2.6"
-zip-extensions = "0.8.2"
+zip = "3.0"
+zip-extensions = "0.8.3"
 ````
 
 See https://github.com/zip-rs/zip2 fur further information about `zip` dependencies.


### PR DESCRIPTION
Upgraded the `zip` crate from version `2.6` to `3.0` and updated related feature flags.

### Changes

- Removed obsolete features and added new ones such as `nt-time` and `jiff-02`.
- Adjusted the default features list accordingly.