### PR TITLE
refactor: use `AsRef<Path>` instead of `&PathBuf`

### DIFF
--- a/src/audit/handlers/duplicates.rs
+++ b/src/audit/handlers/duplicates.rs
@@ -29,7 +29,7 @@ impl Default for DuplicatesHandler {
 impl EntryAuditHandler for DuplicatesHandler {
     fn visit(&mut self, view: &EntryView, report: &mut ZipAuditReport) {
         let added = self.seen.insert(view.enclosed_name.clone());
-        if added == false {
+        if !added {
             report.trace_duplicate(view.enclosed_name.clone());
         }
     }

--- a/src/audit/handlers/entry_view.rs
+++ b/src/audit/handlers/entry_view.rs
@@ -55,8 +55,6 @@ impl EntryView {
             }
         }
 
-        
-
         EntryView {
             compressed_size,
             depth_hint,

--- a/src/audit/handlers/entry_view.rs
+++ b/src/audit/handlers/entry_view.rs
@@ -55,7 +55,9 @@ impl EntryView {
             }
         }
 
-        let view = EntryView {
+        
+
+        EntryView {
             compressed_size,
             depth_hint,
             enclosed_name,
@@ -69,8 +71,6 @@ impl EntryView {
             symlink_target,
             uncompressed_size,
             unix_mode,
-        };
-
-        view
+        }
     }
 }

--- a/src/audit/handlers/symlinks.rs
+++ b/src/audit/handlers/symlinks.rs
@@ -12,11 +12,10 @@ impl EntryAuditHandler for SymlinksHandler {
     fn visit(&mut self, view: &EntryView, report: &mut ZipAuditReport) {
         if view.symlink {
             report.has_symlinks = true;
-            if let Some(t) = &view.symlink_target {
-                if !util::is_within_root(t) {
+            if let Some(t) = &view.symlink_target
+                && !util::is_within_root(t) {
                     report.symlinks_point_outside_root += 1;
                 }
-            }
         }
     }
 }

--- a/src/audit/handlers/symlinks.rs
+++ b/src/audit/handlers/symlinks.rs
@@ -13,9 +13,10 @@ impl EntryAuditHandler for SymlinksHandler {
         if view.symlink {
             report.has_symlinks = true;
             if let Some(t) = &view.symlink_target
-                && !util::is_within_root(t) {
-                    report.symlinks_point_outside_root += 1;
-                }
+                && !util::is_within_root(t)
+            {
+                report.symlinks_point_outside_root += 1;
+            }
         }
     }
 }

--- a/src/audit/handlers/util.rs
+++ b/src/audit/handlers/util.rs
@@ -1,7 +1,7 @@
 use crate::audit::utils::{
     absolute_path_checker, path_depth_analyzer, windows_reserved_name_checker,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub fn is_absolute_path_bytes(name: &[u8]) -> bool {
     absolute_path_checker::is_absolute_path_bytes(name)

--- a/src/audit/handlers/util.rs
+++ b/src/audit/handlers/util.rs
@@ -1,7 +1,7 @@
 use crate::audit::utils::{
     absolute_path_checker, path_depth_analyzer, windows_reserved_name_checker,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn is_absolute_path_bytes(name: &[u8]) -> bool {
     absolute_path_checker::is_absolute_path_bytes(name)
@@ -30,7 +30,7 @@ pub fn contains_control_chars(name: &[u8]) -> bool {
     name.iter().any(|&b| b < 0x20 || b == 0x7F)
 }
 
-pub fn is_windows_reserved_name(path: &PathBuf) -> bool {
+pub fn is_windows_reserved_name(path: impl AsRef<Path>) -> bool {
     windows_reserved_name_checker::is_windows_reserved_name(path)
 }
 

--- a/src/audit/report.rs
+++ b/src/audit/report.rs
@@ -72,6 +72,12 @@ pub enum SuspiciousReason {
     HeaderMismatch,
 }
 
+impl Default for ZipAuditReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ZipAuditReport {
     pub fn new() -> Self {
         Self {

--- a/src/audit/scan.rs
+++ b/src/audit/scan.rs
@@ -18,10 +18,7 @@ pub(crate) fn scan_zip_with_handlers<R: Read + Seek>(
 ) -> ZipResult<ZipAuditReport> {
     let mut report = ZipAuditReport::new();
 
-    let mut zip = match ZipArchive::new(reader) {
-        Ok(z) => z,
-        Err(e) => return Err(e),
-    };
+    let mut zip = ZipArchive::new(reader)?;
 
     for h in handlers.iter_mut() {
         h.begin(zip.len());

--- a/src/audit/utils/absolute_path_checker.rs
+++ b/src/audit/utils/absolute_path_checker.rs
@@ -30,7 +30,7 @@ impl<'a> AbsolutePathChecker<'a> {
 
     #[inline]
     fn is_ascii_alpha(c: u8) -> bool {
-        (b'A'..=b'Z').contains(&c) || (b'a'..=b'z').contains(&c)
+        c.is_ascii_uppercase() || c.is_ascii_lowercase()
     }
 
     #[inline]

--- a/src/audit/utils/windows_reserved_name_checker.rs
+++ b/src/audit/utils/windows_reserved_name_checker.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 const DEVICE_AUXILIARY: &str = "AUX";
 const DEVICE_COM1: &str = "COM1";

--- a/src/audit/utils/windows_reserved_name_checker.rs
+++ b/src/audit/utils/windows_reserved_name_checker.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const DEVICE_AUXILIARY: &str = "AUX";
 const DEVICE_COM1: &str = "COM1";
@@ -61,12 +61,15 @@ const RESERVED_DEVICE_NAMES: [&str; 28] = [
     DEVICE_LPT_SUP_3,
 ];
 
-pub fn is_windows_reserved_name(path: &PathBuf) -> bool {
-    WindowsReservedNameChecker { path }.is_reserved_device_name()
+pub fn is_windows_reserved_name(path: impl AsRef<Path>) -> bool {
+    WindowsReservedNameChecker {
+        path: path.as_ref(),
+    }
+    .is_reserved_device_name()
 }
 
 struct WindowsReservedNameChecker<'a> {
-    path: &'a PathBuf,
+    path: &'a Path,
 }
 
 impl<'a> WindowsReservedNameChecker<'a> {

--- a/src/deflate/default_entry_handler.rs
+++ b/src/deflate/default_entry_handler.rs
@@ -3,7 +3,7 @@ use crate::file_utils::{make_relative_path, path_as_string};
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -14,11 +14,14 @@ impl<T: FileOptionExtension> EntryHandler<T> for DefaultEntryHandler {
     fn handle_entry<W: Write + io::Seek>(
         &self,
         writer: &mut ZipWriter<W>,
-        root: &PathBuf,
-        entry_path: &PathBuf,
+        root: impl AsRef<Path>,
+        entry_path: impl AsRef<Path>,
         file_options: FileOptions<T>,
         buffer: &mut Vec<u8>,
     ) -> ZipResult<()> {
+        let root = root.as_ref();
+        let entry_path = entry_path.as_ref();
+
         let metadata = std::fs::metadata(entry_path)?;
         let relative = make_relative_path(root, entry_path);
 

--- a/src/deflate/default_entry_handler.rs
+++ b/src/deflate/default_entry_handler.rs
@@ -3,7 +3,7 @@ use crate::file_utils::{make_relative_path, path_as_string};
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -26,7 +26,7 @@ impl<T: FileOptionExtension> EntryHandler<T> for DefaultEntryHandler {
         let relative = make_relative_path(root, entry_path);
 
         if metadata.is_file() {
-            let mut f = File::open(&entry_path)?;
+            let mut f = File::open(entry_path)?;
             f.read_to_end(buffer)?;
             writer.start_file(path_as_string(&relative), file_options)?;
             writer.write_all(buffer.as_ref())?;

--- a/src/deflate/entry_handler.rs
+++ b/src/deflate/entry_handler.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -9,8 +9,8 @@ pub trait EntryHandler<T: FileOptionExtension> {
     fn handle_entry<W: Write + io::Seek>(
         &self,
         writer: &mut ZipWriter<W>,
-        root: &PathBuf,
-        entry_path: &PathBuf,
+        root: impl AsRef<Path>,
+        entry_path: impl AsRef<Path>,
         file_options: FileOptions<T>,
         buffer: &mut Vec<u8>,
     ) -> ZipResult<()>;

--- a/src/deflate/entry_handler.rs
+++ b/src/deflate/entry_handler.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};

--- a/src/deflate/preserve_symlinks.rs
+++ b/src/deflate/preserve_symlinks.rs
@@ -3,7 +3,7 @@ use crate::preserve_symlinks_handler::PreserveSymlinksHandler;
 #[allow(unused_imports)]
 use crate::zip_writer::zip_create_from_directory_with_options;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -38,13 +38,13 @@ use zip::write::{FileOptionExtension, FileOptions};
 /// - For general distribution or untrusted extraction environments,
 ///   use `zip_create_from_directory_with_options` instead.
 pub fn zip_create_from_directory_preserve_symlinks_with_options<F, T>(
-    archive_file: &PathBuf,
-    directory: &PathBuf,
+    archive_file: impl AsRef<Path>,
+    directory: impl AsRef<Path>,
     cb_file_options: F,
 ) -> ZipResult<()>
 where
     T: FileOptionExtension,
-    F: Fn(&PathBuf) -> FileOptions<T>,
+    F: Fn(&Path) -> FileOptions<T>,
 {
     let file = File::create(archive_file)?;
     let mut zip_writer = ZipWriter::new(file);

--- a/src/deflate/preserve_symlinks.rs
+++ b/src/deflate/preserve_symlinks.rs
@@ -3,7 +3,7 @@ use crate::preserve_symlinks_handler::PreserveSymlinksHandler;
 #[allow(unused_imports)]
 use crate::zip_writer::zip_create_from_directory_with_options;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};

--- a/src/deflate/preserve_symlinks_handler.rs
+++ b/src/deflate/preserve_symlinks_handler.rs
@@ -3,7 +3,7 @@ use crate::entry_handler::EntryHandler;
 use crate::file_utils::make_relative_path;
 use std::io;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -16,6 +16,12 @@ use zip::write::{FileOptionExtension, FileOptions};
 /// instead.
 pub struct PreserveSymlinksHandler<H = DefaultEntryHandler> {
     inner: H,
+}
+
+impl Default for PreserveSymlinksHandler<DefaultEntryHandler> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PreserveSymlinksHandler<DefaultEntryHandler> {

--- a/src/deflate/preserve_symlinks_handler.rs
+++ b/src/deflate/preserve_symlinks_handler.rs
@@ -3,7 +3,7 @@ use crate::entry_handler::EntryHandler;
 use crate::file_utils::make_relative_path;
 use std::io;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipWriter;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
@@ -43,11 +43,13 @@ where
     fn handle_entry<W: Write + io::Seek>(
         &self,
         writer: &mut ZipWriter<W>,
-        root: &PathBuf,
-        entry_path: &PathBuf,
+        root: impl AsRef<Path>,
+        entry_path: impl AsRef<Path>,
         file_options: FileOptions<T>,
         buffer: &mut Vec<u8>,
     ) -> ZipResult<()> {
+        let entry_path = entry_path.as_ref();
+        let root = root.as_ref();
         let symlink_metadata = std::fs::symlink_metadata(entry_path)?;
         let relative = make_relative_path(root, entry_path);
 

--- a/src/deflate/zip_ignore_entry_handler.rs
+++ b/src/deflate/zip_ignore_entry_handler.rs
@@ -21,6 +21,12 @@ pub struct ZipIgnoreEntryHandler<H = DefaultEntryHandler> {
 
 pub(crate) const IGNORE_FILENAME: &str = ".zipignore";
 
+impl Default for ZipIgnoreEntryHandler<DefaultEntryHandler> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ZipIgnoreEntryHandler<DefaultEntryHandler> {
     pub fn new() -> Self {
         Self {
@@ -71,7 +77,7 @@ impl<H> ZipIgnoreEntryHandler<H> {
         }
         let built = ignore_builder
             .build()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| io::Error::other(e.to_string()))?;
         Ok(built)
     }
 

--- a/src/deflate/zip_ignore_entry_handler.rs
+++ b/src/deflate/zip_ignore_entry_handler.rs
@@ -107,14 +107,15 @@ where
     fn handle_entry<W: Write + io::Seek>(
         &self,
         writer: &mut ZipWriter<W>,
-        root: &PathBuf,
-        entry_path: &PathBuf,
+        root: impl AsRef<Path>,
+        entry_path: impl AsRef<Path>,
         file_options: FileOptions<T>,
         buffer: &mut Vec<u8>,
     ) -> ZipResult<()> {
+        let entry_path = entry_path.as_ref();
         let metadata = std::fs::metadata(entry_path)?;
         let is_dir = metadata.is_dir();
-        if self.is_ignored(root.as_path(), entry_path.as_path(), is_dir) {
+        if self.is_ignored(root.as_ref(), entry_path, is_dir) {
             return Ok(());
         }
         self.inner

--- a/src/deflate/zip_writer.rs
+++ b/src/deflate/zip_writer.rs
@@ -68,7 +68,7 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
             for entry in directory_entry_iterator {
                 let entry_path = entry?.path();
                 let file_options = cb_file_options(entry_path.as_path());
-                handler.handle_entry(self, &directory, &entry_path, file_options, &mut buffer)?;
+                handler.handle_entry(self, directory, &entry_path, file_options, &mut buffer)?;
                 let entry_metadata = std::fs::metadata(entry_path.clone())?;
                 if entry_metadata.is_dir() {
                     paths_queue.push(entry_path.clone());

--- a/src/deflate/zip_writer.rs
+++ b/src/deflate/zip_writer.rs
@@ -4,26 +4,29 @@ use crate::entry_handler::EntryHandler;
 use std::fs::File;
 use std::io;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions, SimpleFileOptions};
 use zip::{CompressionMethod, ZipWriter};
 
 /// Creates a zip archive that contains the files and directories from the specified directory.
-pub fn zip_create_from_directory(archive_file: &PathBuf, directory: &PathBuf) -> ZipResult<()> {
+pub fn zip_create_from_directory(
+    archive_file: impl AsRef<Path>,
+    directory: impl AsRef<Path>,
+) -> ZipResult<()> {
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
     zip_create_from_directory_with_options(archive_file, directory, |_| options)
 }
 
 /// Creates a zip archive that contains the files and directories from the specified directory.
 pub fn zip_create_from_directory_with_options<F, T>(
-    archive_file: &PathBuf,
-    directory: &PathBuf,
+    archive_file: impl AsRef<Path>,
+    directory: impl AsRef<Path>,
     cb_file_options: F,
 ) -> ZipResult<()>
 where
     T: FileOptionExtension,
-    F: Fn(&PathBuf) -> FileOptions<T>,
+    F: Fn(&Path) -> FileOptions<T>,
 {
     let file = File::create(archive_file)?;
     let mut zip_writer = ZipWriter::new(file);
@@ -37,24 +40,26 @@ where
 }
 
 impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
-    fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()> {
+    fn create_from_directory(&mut self, directory: impl AsRef<Path>) -> ZipResult<()> {
         let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
         self.create_from_directory_with_options(directory, |_| options, &DefaultEntryHandler)
     }
 
     fn create_from_directory_with_options<F, T, H>(
         &mut self,
-        directory: &PathBuf,
+        directory: impl AsRef<Path>,
         cb_file_options: F,
         handler: &H,
     ) -> ZipResult<()>
     where
         T: FileOptionExtension,
-        F: Fn(&PathBuf) -> FileOptions<T>,
+        F: Fn(&Path) -> FileOptions<T>,
         H: EntryHandler<T>,
     {
+        let directory = directory.as_ref();
+
         let mut paths_queue: Vec<PathBuf> = vec![];
-        paths_queue.push(directory.clone());
+        paths_queue.push(directory.to_path_buf());
 
         let mut buffer = Vec::new();
 
@@ -62,7 +67,7 @@ impl<W: Write + io::Seek> ZipWriterExtensions for ZipWriter<W> {
             let directory_entry_iterator = std::fs::read_dir(next)?;
             for entry in directory_entry_iterator {
                 let entry_path = entry?.path();
-                let file_options = cb_file_options(&entry_path);
+                let file_options = cb_file_options(entry_path.as_path());
                 handler.handle_entry(self, &directory, &entry_path, file_options, &mut buffer)?;
                 let entry_metadata = std::fs::metadata(entry_path.clone())?;
                 if entry_metadata.is_dir() {

--- a/src/deflate/zip_writer_extensions.rs
+++ b/src/deflate/zip_writer_extensions.rs
@@ -1,21 +1,21 @@
 use crate::entry_handler::EntryHandler;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
 
 pub trait ZipWriterExtensions {
     /// Creates a zip archive that contains the files and directories from the specified directory.
-    fn create_from_directory(&mut self, directory: &PathBuf) -> ZipResult<()>;
+    fn create_from_directory(&mut self, directory: impl AsRef<Path>) -> ZipResult<()>;
 
     /// Creates a zip archive that contains the files and directories from the specified directory, uses the specified compression level.
     fn create_from_directory_with_options<F, T, H>(
         &mut self,
-        directory: &PathBuf,
+        directory: impl AsRef<Path>,
         cb_file_options: F,
         handler: &H,
     ) -> ZipResult<()>
     where
         T: FileOptionExtension,
-        F: Fn(&PathBuf) -> FileOptions<T>,
+        F: Fn(&Path) -> FileOptions<T>,
         H: EntryHandler<T>;
 }

--- a/src/deflate/zip_writer_extensions.rs
+++ b/src/deflate/zip_writer_extensions.rs
@@ -1,5 +1,5 @@
 use crate::entry_handler::EntryHandler;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::result::ZipResult;
 use zip::write::{FileOptionExtension, FileOptions};
 

--- a/src/inflate/is_zip.rs
+++ b/src/inflate/is_zip.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::result::ZipResult;
 
 /// Determines whether the specified file is a ZIP file, or not.

--- a/src/inflate/is_zip.rs
+++ b/src/inflate/is_zip.rs
@@ -1,10 +1,12 @@
 use std::fs::File;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::result::ZipResult;
 
 /// Determines whether the specified file is a ZIP file, or not.
-pub fn try_is_zip(file: &PathBuf) -> ZipResult<bool> {
+pub fn try_is_zip(file: impl AsRef<Path>) -> ZipResult<bool> {
+    let file = file.as_ref();
+
     const ZIP_SIGNATURE: [u8; 2] = [0x50, 0x4b];
     const ZIP_ARCHIVE_FORMAT: [u8; 6] = [0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
     let mut file = File::open(file)?;
@@ -27,6 +29,6 @@ pub fn try_is_zip(file: &PathBuf) -> ZipResult<bool> {
 }
 
 /// Determines whether the specified file is a ZIP file, or not.
-pub fn is_zip(file: &PathBuf) -> bool {
+pub fn is_zip(file: impl AsRef<Path>) -> bool {
     try_is_zip(file).unwrap_or_default()
 }

--- a/src/inflate/zip_archive.rs
+++ b/src/inflate/zip_archive.rs
@@ -2,13 +2,14 @@ use crate::file_utils::file_write_all_bytes;
 use crate::inflate::zip_archive_extensions::ZipArchiveExtensions;
 use std::io;
 use std::io::{Error, ErrorKind, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipArchive;
 use zip::read::ZipFile;
 use zip::result::{ZipError, ZipResult};
-
 impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
-    fn extract(&mut self, target_directory: &PathBuf) -> ZipResult<()> {
+    fn extract(&mut self, target_directory: impl AsRef<Path>) -> ZipResult<()> {
+        let target_directory = target_directory.as_ref();
+
         if !target_directory.is_dir() {
             return Err(ZipError::Io(Error::new(
                 ErrorKind::InvalidInput,
@@ -39,13 +40,13 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
     fn extract_file(
         &mut self,
         file_number: usize,
-        destination_file_path: &PathBuf,
+        destination_file_path: impl AsRef<Path>,
         overwrite: bool,
     ) -> ZipResult<()> {
         let mut buffer: Vec<u8> = Vec::new();
         self.extract_file_to_memory(file_number, &mut buffer)?;
         file_write_all_bytes(
-            destination_file_path.to_path_buf(),
+            destination_file_path.as_ref().to_path_buf(),
             buffer.as_ref(),
             overwrite,
         )?;
@@ -73,7 +74,9 @@ impl<R: Read + io::Seek> ZipArchiveExtensions for ZipArchive<R> {
         Ok(next.mangled_name())
     }
 
-    fn file_number(&mut self, entry_path: &PathBuf) -> Option<usize> {
+    fn file_number(&mut self, entry_path: impl AsRef<Path>) -> Option<usize> {
+        let entry_path = entry_path.as_ref();
+
         for file_number in 0..self.len() {
             if let Ok(next) = self.by_index(file_number) {
                 let sanitized_name = next.mangled_name();

--- a/src/inflate/zip_archive_extensions.rs
+++ b/src/inflate/zip_archive_extensions.rs
@@ -1,15 +1,15 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::result::ZipResult;
 
 pub trait ZipArchiveExtensions {
     /// Extracts the current archive to the given directory path.
-    fn extract(&mut self, path: &PathBuf) -> ZipResult<()>;
+    fn extract(&mut self, path: impl AsRef<Path>) -> ZipResult<()>;
 
     /// Extracts an entry in the zip archive to a file.
     fn extract_file(
         &mut self,
         file_number: usize,
-        destination_file_path: &PathBuf,
+        destination_file_path: impl AsRef<Path>,
         overwrite: bool,
     ) -> ZipResult<()>;
 
@@ -21,5 +21,5 @@ pub trait ZipArchiveExtensions {
     fn entry_path(&mut self, file_number: usize) -> ZipResult<PathBuf>;
 
     /// Finds the index of the specified entry.
-    fn file_number(&mut self, entry_path: &PathBuf) -> Option<usize>;
+    fn file_number(&mut self, entry_path: impl AsRef<Path>) -> Option<usize>;
 }

--- a/src/inflate/zip_extract.rs
+++ b/src/inflate/zip_extract.rs
@@ -1,11 +1,11 @@
 use crate::inflate::zip_archive_extensions::ZipArchiveExtensions;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zip::ZipArchive;
 use zip::result::{ZipError, ZipResult};
 
 /// Extracts a ZIP file to the given directory.
-pub fn zip_extract(archive_file: &PathBuf, target_dir: &PathBuf) -> ZipResult<()> {
+pub fn zip_extract(archive_file: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> ZipResult<()> {
     let file = File::open(archive_file)?;
     let mut archive = ZipArchive::new(file)?;
     archive.extract(target_dir)
@@ -13,11 +13,15 @@ pub fn zip_extract(archive_file: &PathBuf, target_dir: &PathBuf) -> ZipResult<()
 
 /// Extracts and entry in the ZIP archive to the given directory.
 pub fn zip_extract_file(
-    archive_file: &PathBuf,
-    entry_path: &PathBuf,
-    target_dir: &PathBuf,
+    archive_file: impl AsRef<Path>,
+    entry_path: impl AsRef<Path>,
+    target_dir: impl AsRef<Path>,
     overwrite: bool,
 ) -> ZipResult<()> {
+    let archive_file = archive_file.as_ref();
+    let entry_path = entry_path.as_ref();
+    let target_dir = target_dir.as_ref();
+
     let file = File::open(archive_file)?;
     let mut archive = ZipArchive::new(file)?;
     let file_number: usize = match archive.file_number(entry_path) {
@@ -30,8 +34,8 @@ pub fn zip_extract_file(
 
 /// Extracts an entry in the ZIP archive to the given memory buffer.
 pub fn zip_extract_file_to_memory(
-    archive_file: &PathBuf,
-    entry_path: &PathBuf,
+    archive_file: impl AsRef<Path>,
+    entry_path: impl AsRef<Path>,
     buffer: &mut Vec<u8>,
 ) -> ZipResult<()> {
     let file = File::open(archive_file)?;

--- a/src/inflate/zip_extract.rs
+++ b/src/inflate/zip_extract.rs
@@ -1,6 +1,6 @@
 use crate::inflate::zip_archive_extensions::ZipArchiveExtensions;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use zip::ZipArchive;
 use zip::result::{ZipError, ZipResult};
 

--- a/src/tests/audit/utils/windows_reserved_name_checker_test.rs
+++ b/src/tests/audit/utils/windows_reserved_name_checker_test.rs
@@ -4,7 +4,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn reserved(name: &str) -> bool {
-        is_windows_reserved_name(&PathBuf::from(name))
+        is_windows_reserved_name(PathBuf::from(name))
     }
 
     #[test]

--- a/src/tests/preserve_symlinks_test.rs
+++ b/src/tests/preserve_symlinks_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::preserve_symlinks::zip_create_from_directory_preserve_symlinks_with_options;
     use std::fs::{self, File};
     use std::io::Read;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::{TempDir, tempdir};
     use zip::CompressionMethod;
     use zip::read::{ZipArchive, ZipFile};
@@ -22,9 +22,7 @@ mod tests {
         zip_create_from_directory_preserve_symlinks_with_options(
             &archive_path,
             &source.source_folder_path,
-            |_p: &PathBuf| {
-                SimpleFileOptions::default().compression_method(CompressionMethod::Stored)
-            },
+            |_p: &Path| SimpleFileOptions::default().compression_method(CompressionMethod::Stored),
         )
         .expect("Failed to create archive");
 
@@ -100,8 +98,12 @@ mod tests {
         archive
     }
 
-    fn add_regular_file(root_folder_path: &PathBuf, name: String, content: String) -> PathBuf {
-        let file_path = root_folder_path.join(name);
+    fn add_regular_file(
+        root_folder_path: impl AsRef<Path>,
+        name: String,
+        content: String,
+    ) -> PathBuf {
+        let file_path = root_folder_path.as_ref().join(name);
         fs::write(&file_path, content).unwrap();
         file_path
     }

--- a/src/tests/zip_ignore_test.rs
+++ b/src/tests/zip_ignore_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use crate::zip_ignore_entry_handler::IGNORE_FILENAME;
     use std::fs;
     use std::fs::File;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::{TempDir, tempdir};
     use zip::read::ZipArchive;
     use zip::write::SimpleFileOptions;
@@ -105,7 +105,7 @@ mod tests {
             zip_writer
                 .create_from_directory_with_options(
                     &self.source_folder_path,
-                    |_p: &PathBuf| options,
+                    |_p: &Path| options,
                     &ZipIgnoreEntryHandler::new(),
                 )
                 .expect("Failed to create archive");

--- a/src/utilities/file_utils.rs
+++ b/src/utilities/file_utils.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io;
 use std::io::{Error, ErrorKind, Write};
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// Writes all bytes to a file.
 pub fn file_write_all_bytes(path: PathBuf, bytes: &[u8], overwrite: bool) -> io::Result<usize> {
@@ -17,7 +17,10 @@ pub fn file_write_all_bytes(path: PathBuf, bytes: &[u8], overwrite: bool) -> io:
 }
 
 /// Returns a relative path from one path to another.
-pub(crate) fn make_relative_path(root: &PathBuf, current: &PathBuf) -> PathBuf {
+pub(crate) fn make_relative_path(root: impl AsRef<Path>, current: impl AsRef<Path>) -> PathBuf {
+    let root = root.as_ref();
+    let current = current.as_ref();
+
     let mut result = PathBuf::new();
     let root_components = root.components().collect::<Vec<Component>>();
     let current_components = current.components().collect::<Vec<_>>();

--- a/src/utilities/file_utils.rs
+++ b/src/utilities/file_utils.rs
@@ -46,7 +46,7 @@ pub(crate) fn path_as_string(path: &std::path::Path) -> String {
             if !path_str.is_empty() {
                 path_str.push('/');
             }
-            path_str.push_str(&*os_str.to_string_lossy());
+            path_str.push_str(&os_str.to_string_lossy());
         }
     }
     path_str


### PR DESCRIPTION
Replaced most of the occurrences of `&PathBuf` with `AsRef<Path>`. 

There are breaking changes to this PR, and they can be found in #40 